### PR TITLE
Add StarmapRouteSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This module allows you to easy retrive online information related to the RSI web
 | StarmapStarSystems    | Get star-system from the starmap by code |
 | StarmapCelestialObjects   | Get celestial objects from the starmap by name |
 | StarmapSearch | Search object from the starmap by name |
+| StarmapRouteSearch   | Find routes from position to destionation |
 | Stats | Get general information like the numbers of citizens |
 | Telemetry | Get some telemetry info |
 | User  | Find information about a user by handle |

--- a/rsi_scraper/__init__.py
+++ b/rsi_scraper/__init__.py
@@ -7,7 +7,9 @@ from .ship import Ship
 from .starmap import (
     StarmapSystems, StarmapTunnels, StarmapSpecies,
     StarmapAffiliations, StarmapStarSystems,
-    StarmapCelestialObjects, StarmapSearch)
+    StarmapCelestialObjects, StarmapSearch,
+    StarmapRouteSearch
+)
 from .stats import Stats
 from .telemetry import Telemetry
 from .user import User
@@ -23,6 +25,7 @@ __all__ = [
     'StarmapSystems', 'StarmapTunnels', 'StarmapSpecies',
     'StarmapAffiliations', 'StarmapStarSystems',
     'StarmapCelestialObjects', 'StarmapSearch',
+    'StarmapRouteSearch',
     'Stats',
     'Telemetry',
     'User',

--- a/rsi_scraper/starmap.py
+++ b/rsi_scraper/starmap.py
@@ -88,7 +88,9 @@ class StarmapSpecies(ICommand):
         if self.name is None:
             res = species
         else:
-            res = list(filter(lambda s: str(s['name']).lower() == str(self.name).lower() or str(s['code']).lower() == str(self.name).lower(), species))
+            res = list(filter(
+                lambda s: str(s['name']).lower() == str(self.name).lower() or str(s['code']).lower() == str(
+                    self.name).lower(), species))
 
         if len(res) == 0:
             return None
@@ -220,6 +222,48 @@ class StarmapSearch(ICommand):
         res = {
             "systems": resp['data']['systems']['resultset'],
             "objects": resp['data']['objects']['resultset']
+        }
+        return res
+
+
+# {"departure":"STANTON.LZS.LORVILLE","destination":"STANTON.LZS.AREA18","ship_size":"L"}
+
+class StarmapRouteSearch(ICommand):
+    """StarmapRouteSearch
+    """
+
+    __url_find = "https://robertsspaceindustries.com/api/starmap/routes/find"
+
+    def __init__(self, _from: str, to: str):
+        """
+        Args:
+            search (str): The search.
+        """
+        self._from = _from
+        self._to = to
+
+    async def execute_async(self):
+        return self.execute()
+
+    def execute(self):
+        data = {
+            "departure": self._from,
+            "destination": self._to,
+            "ship_size": "L",
+        }
+        req = Connector().request(self.__url_find, data)
+        if req is None or req.status_code != 200:
+            return None
+
+        resp = req.json()
+
+        # check response
+        if resp['success'] != 1 or "data" not in resp:
+            return None
+
+        res = {
+            "shortest": resp['data']['shortest'],
+            "leastjumps": resp['data']['leastjumps']
         }
         return res
 

--- a/rsi_scraper/starmap.py
+++ b/rsi_scraper/starmap.py
@@ -226,8 +226,6 @@ class StarmapSearch(ICommand):
         return res
 
 
-# {"departure":"STANTON.LZS.LORVILLE","destination":"STANTON.LZS.AREA18","ship_size":"L"}
-
 class StarmapRouteSearch(ICommand):
     """StarmapRouteSearch
     """

--- a/rsi_scraper/starmap.py
+++ b/rsi_scraper/starmap.py
@@ -234,13 +234,16 @@ class StarmapRouteSearch(ICommand):
 
     __url_find = "https://robertsspaceindustries.com/api/starmap/routes/find"
 
-    def __init__(self, _from: str, to: str):
+    def __init__(self, _from: str, to: str, ship_size: str):
         """
         Args:
-            search (str): The search.
+            _from (str): The object code for the departing system
+            to (str): The object code for the destination system
+            ship_size (str): The size of the ship traveling. Valid values are S, M, L
         """
         self._from = _from
         self._to = to
+        self._size = ship_size
 
     async def execute_async(self):
         return self.execute()
@@ -249,7 +252,7 @@ class StarmapRouteSearch(ICommand):
         data = {
             "departure": self._from,
             "destination": self._to,
-            "ship_size": "L",
+            "ship_size": self._size
         }
         req = Connector().request(self.__url_find, data)
         if req is None or req.status_code != 200:

--- a/tests/schemas/starmap_route_search.json
+++ b/tests/schemas/starmap_route_search.json
@@ -1,0 +1,201 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+      "shortest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "first_jump": {
+            "type": [
+                "string",
+                "null"
+            ]
+          },
+          "flight_distance": {
+            "type": "number"
+          },
+          "jumps": {
+            "type": "integer"
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "system_id": {
+                  "type": "string"
+                },
+                "system_code": {
+                  "type": "string"
+                },
+                "object_id": {
+                  "type": "string"
+                },
+                "object_code": {
+                  "type": "string"
+                },
+                "segment_type": {
+                  "type": "string"
+                },
+                "segment_distance": {
+                  "type": [
+                    "number",
+                    "integer",
+                    "null"
+                  ]
+                },
+                "is_departure": {
+                  "type": [
+                    "integer",
+                    "boolean"
+                  ]
+                },
+                "is_destination": {
+                  "type": [
+                    "boolean",
+                    "integer"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "type",
+                "system_id",
+                "system_code",
+                "object_id",
+                "object_code",
+                "segment_type",
+                "segment_distance",
+                "is_departure",
+                "is_destination"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "label",
+          "first_jump",
+          "flight_distance",
+          "jumps",
+          "segments"
+        ]
+      },
+      "leastjumps": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "first_jump": {
+            "type": [
+                "string",
+                "null"
+            ]
+          },
+          "flight_distance": {
+            "type": "number"
+          },
+          "jumps": {
+            "type": "integer"
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "system_id": {
+                  "type": "string"
+                },
+                "system_code": {
+                  "type": "string"
+                },
+                "object_id": {
+                  "type": "string"
+                },
+                "object_code": {
+                  "type": "string"
+                },
+                "segment_type": {
+                  "type": "string"
+                },
+                "segment_distance": {
+                  "type": [
+                    "number",
+                    "integer",
+                    "null"
+                  ]
+                },
+                "is_departure": {
+                  "type": [
+                    "integer",
+                    "boolean"
+                  ]
+                },
+                "is_destination": {
+                  "type": [
+                    "boolean",
+                    "integer"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "type",
+                "system_id",
+                "system_code",
+                "object_id",
+                "object_code",
+                "segment_type",
+                "segment_distance",
+                "is_departure",
+                "is_destination"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "label",
+          "first_jump",
+          "flight_distance",
+          "jumps",
+          "segments"
+        ]
+      }
+    },
+    "required": [
+      "shortest",
+      "leastjumps"
+    ]
+  }
+

--- a/tests/test_starmap.py
+++ b/tests/test_starmap.py
@@ -66,3 +66,22 @@ def test_request_species():
     assert data is not None
 
     assert_valid_schema(data, 'starmap_species.json')
+
+
+@pytest.mark.starmap
+@pytest.mark.parametrize('_from, to, ship_size', [
+    ('STANTON.LZS.LORVILLE', 'STANTON.LZS.AREA18', "M"),
+    ('STANTON.LZS.LORVILLE', 'STANTON.LZS.AREA18', "L"),
+    ('STANTON.LZS.LORVILLE', 'STANTON.LZS.AREA18', "S"),
+    ('SOL.PLANETS.EARTH', 'PYRO.PLANETS.PYROI', 'L'),
+    ('ORION.PLANET.ORIONIIIARMITAGE', 'AYRKA.PLANET.AYRKAII', 'S'),
+])
+def test_request_route_search(_from, to, ship_size):
+    from rsi_scraper import StarmapRouteSearch
+
+    object = StarmapRouteSearch(_from, to, ship_size)
+    data = object.execute()
+
+    assert data is not None
+
+    assert_valid_schema(data, 'starmap_route_search.json')


### PR DESCRIPTION
Adds the Starmap Route searching endpoint which takes in the names of two objects and calculates the fastest route between them using this endpoint: https://robertsspaceindustries.com/api/starmap/routes/find 
